### PR TITLE
Computer Use対応OSをmacOS Sonoma 14.0以降に明確化

### DIFF
--- a/docs/claude-computer-use-guide.md
+++ b/docs/claude-computer-use-guide.md
@@ -4,7 +4,7 @@
 
 > **⚠ 現在のステータス：リサーチプレビュー**
 > - 対象プラン：Pro / Max のみ
-> - 対応OS：macOS のみ（Windows / Linux は未対応）
+> - 対応OS：**macOS Sonoma（14.0）以降のみ**（Windows / Linux / iOS 単体は未対応）
 > - Claude デスクトップアプリの起動が必須
 > - 正式リリースではないため、機能や仕様が変更される可能性がある
 
@@ -16,7 +16,7 @@
 |------|------|
 | **ステータス** | リサーチプレビュー（正式版ではない） |
 | **プラン** | Claude Pro または Max |
-| **OS** | macOS のみ（Windows / Linux は未対応） |
+| **OS** | **macOS Sonoma（14.0）以降**のみ（Windows / Linux / iOS 単体は未対応） |
 | **アプリ** | Claude デスクトップアプリ（最新版）の起動が必須 |
 | **ブラウザ操作** | Google Chrome（拡張機能が必要） |
 

--- a/guide.html
+++ b/guide.html
@@ -145,11 +145,11 @@
 <body>
   <header>
     <h1>Claude新機能のPC操作試してみた</h1>
-    <p>Computer Use — Research Preview</p>
+    <p>Computer Use — Research Preview｜macOS Sonoma（14.0）以降限定</p>
   </header>
   <div class="container">
     <div class="intro">
-      Claudeの新機能「Computer Use」を使うと、AIがPC画面を見ながらキーボード・マウスを操作してくれます。特別なAPIキーや複雑な設定ファイルは不要で、対応プラン（Pro / Max）に加入していればデスクトップアプリ側で機能を有効化するだけで始められます。セットアップは3ステップで完了します。
+      Claudeの新機能「Computer Use」を使うと、AIがPC画面を見ながらキーボード・マウスを操作してくれます。特別なAPIキーや複雑な設定ファイルは不要で、対応プラン（Pro / Max）に加入していればデスクトップアプリ側で機能を有効化するだけで始められます。セットアップは3ステップで完了します。<br><br><strong>対応環境：macOS Sonoma（14.0）以降のMac限定</strong>（Windows・Linux・iOSデバイス単体では使用不可）
     </div>
     <div class="steps">
       <div class="step">


### PR DESCRIPTION
## Summary
- Computer Useの対応OSを「macOS Sonoma（14.0）以降限定」に明確化
- Windows・Linux・iOS単体では使用不可であることをガイドとホームページの両方に反映

## Test plan
- [ ] docs/claude-computer-use-guide.md の前提条件表を確認
- [ ] guide.html のイントロ文を確認

https://claude.ai/code/session_014pGpEd38DLAk3b6T2e8XMr