### PR TITLE
Coworkデーモンのセットアップ手順を追加

### DIFF
--- a/docs/claude-computer-use-guide.md
+++ b/docs/claude-computer-use-guide.md
@@ -36,7 +36,29 @@ Claude の「**Cowork**」タブ内にある **Dispatch（ディスパッチ）*
 
 ## 3. セットアップ手順
 
-### 3.1 Claude デスクトップアプリを開く
+### 3.0 Cowork デーモンのインストール（ターミナルからセットアップする場合）
+
+GUI の Dispatch 設定画面を使わず、ターミナルから直接セットアップすることも可能。
+
+```bash
+# Cowork デーモンをインストール
+curl -fsSL https://cowork.anthropic.com/install.sh | bash
+
+# 起動して Claude app とペアリング
+cowork start
+# → ターミナルに QR コードが表示される
+# スマホの Claude app でスキャンしてペアリング完了
+
+# ステータス確認
+cowork status
+# → "Paired: YES  |  Status: Ready" が出れば設定完了
+```
+
+**ポイント**：
+- スマホしか手元にない場合でも、SSH 等でリモートの Mac にアクセスして `cowork start` → スマホの Claude app で QR スキャンという流れでペアリングできる
+- ペアリング後は Claude app 側から Dispatch タスクを投げられる
+
+### 3.1 Claude デスクトップアプリを開く（GUI からセットアップする場合）
 
 上部タブで **「Cowork」** を選択し、左サイドバーから **「Dispatch」** をクリック。
 


### PR DESCRIPTION
## Summary
- ターミナルからCoworkデーモンをインストール・ペアリングする手順を追加
- `curl` → `cowork start` → QRスキャン → `cowork status` の流れを記載
- GUI（Dispatch画面）との使い分けを明確化

## Test plan
- [ ] セクション3.0と3.1の見出し階層が正しいことを確認

https://claude.ai/code/session_014pGpEd38DLAk3b6T2e8XMr